### PR TITLE
Adding _getRowComponents function

### DIFF
--- a/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/GridTest.kt
+++ b/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/GridTest.kt
@@ -15,6 +15,7 @@ import com.vaadin.flow.component.grid.HeaderRow
 import com.vaadin.flow.component.grid.ItemClickEvent
 import com.vaadin.flow.component.grid.dnd.GridDropMode
 import com.vaadin.flow.component.html.Label
+import com.vaadin.flow.component.html.Span
 import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.data.binder.BeanValidationBinder
 import com.vaadin.flow.data.provider.ListDataProvider
@@ -251,6 +252,21 @@ internal fun DynaNodeGroup.gridTestbatch() {
             }
             expectThrows(AssertionError::class, "Grid[dataprovider='ListDataProvider2{11 items}'] column name: ComponentRenderer produced Label[] which is not a button nor a ClickNotifier - please use _getCellComponent() instead") {
                 grid._clickRenderer(8, "name")
+            }
+        }
+    }
+
+    group("_getRowComponents") {
+        test("_getRowComponents returns row components") {
+            val grid: Grid<TestPerson> = Grid<TestPerson>().apply {
+                addColumn(ComponentRenderer<Span, TestPerson> { person -> Span(person.name) }).key = "name"
+                addColumn(ComponentRenderer<Span, TestPerson> { person -> Span(person.age.toString()) }).key = "age"
+                setItems2((0..2).map { TestPerson("name $it", it) })
+                isEnabled = false
+            }
+            (0..2).forEach {
+                expect(listOf("name $it", it.toString())) { grid._getRowComponents(it).map { it._text } }
+                expect(listOf(true, true)) { grid._getRowComponents(it).map { it is Span } }
             }
         }
     }

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/Grid.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/Grid.kt
@@ -298,6 +298,16 @@ public fun <T : Any> Grid<T>._getCellComponent(
 }
 
 /**
+ * Retrieves the list of components produced by [ComponentRenderer] in given [Grid] row. Fails if the
+ * renderer is not a [ComponentRenderer] in one of grid columns.
+ *
+ * @param rowIndex the row index, 0 or higher.
+ * @throws IllegalStateException if the renderer of one of the grid columns is not [ComponentRenderer].
+ */
+public fun <T : Any> Grid<T>._getRowComponents(rowIndex: Int): List<Component> =
+        columns.filter { it.isVisible }.map { _getCellComponent(rowIndex, it.key) }
+
+/**
  * Returns the formatted value as a String. Does not use renderer to render the value - simply calls value provider and presentation provider
  * and converts the result to string (even if the result is a [Component]).
  * @param rowIndex the row index, 0 or higher.


### PR DESCRIPTION
Adding a function that retrieves the list of components produced by `ComponentRenderer` in given `Grid` row.

It's based on `_getCellComponent` but it retrives all cell components in a specific row.