### PR TITLE
Get fields inside grid editor

### DIFF
--- a/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/GridTest.kt
+++ b/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/GridTest.kt
@@ -478,6 +478,25 @@ internal fun DynaNodeGroup.gridTestbatch() {
             expect(true) { ran }
             expect("name 0") { editorField.value }
         }
+        test("opening editor then get field to set value") {
+            val grid = UI.getCurrent().grid<TestPerson> {
+                setItems2((0..10).map { TestPerson("name $it", it) })
+                val binder = beanValidationBinder<TestPerson>()
+                editor.binder = binder
+                addColumn("name").apply {
+                    val editorField = TextField()
+                    editorField.apply {
+                        bind(binder).bind("name")
+                    }
+                    setEditorComponent(editorField)
+                }
+            }
+
+            // the test itself
+            grid.editor._editItem(TestPerson("name 0", 0))
+            val editorField = grid._get<TextField>()
+            expect("name 0") { editorField.value }
+        }
         test("opening editor fails on incorrect binding") {
             val grid = UI.getCurrent().grid<TestPerson> {
                 setItems2((0..10).map { TestPerson("name $it", it) })

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/TestingLifecycleHook.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/TestingLifecycleHook.kt
@@ -58,7 +58,8 @@ public interface TestingLifecycleHook {
             val footerComponents: List<Component> = component.footerRows
                     .flatMap { it.cells.map { it.component } }
                     .filterNotNull()
-            headerComponents + footerComponents + component.children.toList()
+            headerComponents + footerComponents + component.children.toList() +
+                    component.columns.map { it.editorComponent }
         }
         is MenuItemBase<*, *, *> -> {
             // also include component.children: https://github.com/mvysny/karibu-testing/issues/76

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/TestingLifecycleHook.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/TestingLifecycleHook.kt
@@ -58,8 +58,9 @@ public interface TestingLifecycleHook {
             val footerComponents: List<Component> = component.footerRows
                     .flatMap { it.cells.map { it.component } }
                     .filterNotNull()
-            headerComponents + footerComponents + component.children.toList() +
-                    component.columns.map { it.editorComponent }
+            val editorComponents: List<Component> = component.columns
+                    .mapNotNull { it.editorComponent }
+            headerComponents + footerComponents + editorComponents + component.children.toList()
         }
         is MenuItemBase<*, *, *> -> {
             // also include component.children: https://github.com/mvysny/karibu-testing/issues/76


### PR DESCRIPTION
After calling `grid.editor._editItem`, the editor fields should be visible and I can get them to edit the item values.

Now `grid._get<TextField>` or `grid._find<TextField>` doesn't find the fields. So this PR is to be able to get the field editors.

Actually there is another way to do that with `grid._get<Grid.Column<*>` and then call `editorComponent`. But `grid._find<TextField>` may be easier and more explicit.