### PR TITLE
Allow to provide exception as a reason for upload fail call

### DIFF
--- a/karibu-testing-v10-groovy/src/main/groovy/com/github/mvysny/kaributesting/v10/groovy/UploadUtils.groovy
+++ b/karibu-testing-v10-groovy/src/main/groovy/com/github/mvysny/kaributesting/v10/groovy/UploadUtils.groovy
@@ -4,6 +4,7 @@ import com.github.mvysny.kaributesting.v10.UploadKt
 import com.vaadin.flow.component.upload.Upload
 import groovy.transform.CompileStatic
 import org.jetbrains.annotations.NotNull
+import org.jetbrains.annotations.Nullable
 
 /**
  * {@link Upload}-related utilities.
@@ -51,10 +52,12 @@ class UploadUtils {
      * Tests the "upload failed" scenario. First invokes
      * {@link com.vaadin.flow.component.upload.StartedEvent}, then polls
      * {@link Upload#getReceiver()} and closes it immediately without writing anything, then
-     * fires {@link com.vaadin.flow.component.upload.FailedEvent} and {@link com.vaadin.flow.component.upload.FinishedEvent}.
+     * fires {@link com.vaadin.flow.component.upload.FailedEvent} with an exception as a reason
+     * and then {@link com.vaadin.flow.component.upload.FinishedEvent}.
      */
     static void _uploadFail(@NotNull Upload self, @NotNull String fileName,
-                            @NotNull String mimeType = URLConnection.guessContentTypeFromName(fileName)) {
-        UploadKt._uploadFail(self, fileName, mimeType)
+                            @NotNull String mimeType = URLConnection.guessContentTypeFromName(fileName),
+                            @Nullable Exception exception = null) {
+        UploadKt._uploadFail(self, fileName, mimeType, exception)
     }
 }

--- a/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/UploadTest.kt
+++ b/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/UploadTest.kt
@@ -105,10 +105,11 @@ internal fun DynaNodeGroup.uploadTestbatch() {
         var startedCalled = false
         var failedCalled = false
         var finishedCalled = false
+        val exception = RuntimeException("simulated")
         upload.addFailedListener {
             expect("hello.txt") { it.fileName }
             expect("text/plain") { it.mimeType }
-            expect(null) { it.reason }
+            expect(exception) { it.reason }
             failedCalled = true
         }
         upload.addStartedListener {
@@ -124,7 +125,10 @@ internal fun DynaNodeGroup.uploadTestbatch() {
             expect("text/plain") { it.mimeType }
             finishedCalled = true
         }
-        upload._uploadFail("hello.txt")
+        upload._uploadFail(
+            fileName = "hello.txt",
+            exception = exception
+        )
         expect(true) { startedCalled }
         expect(true) { failedCalled }
         expect(true) { finishedCalled }

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/Upload.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/Upload.kt
@@ -54,13 +54,13 @@ public fun Upload._uploadInterrupt(fileName: String, mimeType: String = URLConne
 /**
  * Tests the "upload failed" scenario. First invokes [StartedEvent], then polls
  * [Upload.receiver] and closes it immediately without writing anything, then
- * fires [FailedEvent] and [FinishedEvent].
+ * fires [FailedEvent] with an [exception] as a reason and then [FinishedEvent].
  */
 @JvmOverloads
-public fun Upload._uploadFail(fileName: String, mimeType: String = URLConnection.guessContentTypeFromName(fileName)) {
+public fun Upload._uploadFail(fileName: String, mimeType: String = URLConnection.guessContentTypeFromName(fileName), exception: Exception? = null) {
     checkEditableByUser()
     _fireEvent(StartedEvent(this, fileName, mimeType, 100L))
     receiver.receiveUpload(fileName, mimeType).use {  }
-    _fireEvent(FailedEvent(this, fileName, mimeType, 0L))
+    _fireEvent(FailedEvent(this, fileName, mimeType, 0L, exception))
     _fireEvent(FinishedEvent(this, fileName, mimeType, 0L))
 }

--- a/karibu-testing-v8/src/main/kotlin/com/github/mvysny/kaributesting/v8/Upload.kt
+++ b/karibu-testing-v8/src/main/kotlin/com/github/mvysny/kaributesting/v8/Upload.kt
@@ -52,13 +52,13 @@ public fun Upload._uploadInterrupt(fileName: String, mimeType: String = URLConne
 /**
  * Tests the "upload failed" scenario. First invokes [Upload.StartedEvent], then polls
  * [Upload.receiver] and closes it immediately without writing anything, then
- * fires [Upload.FailedEvent] and [Upload.FinishedEvent].
+ * fires [FailedEvent] with an [exception] as a reason and then [FinishedEvent].
  */
 @JvmOverloads
-public fun Upload._uploadFail(fileName: String, mimeType: String = URLConnection.guessContentTypeFromName(fileName)) {
+public fun Upload._uploadFail(fileName: String, mimeType: String = URLConnection.guessContentTypeFromName(fileName), exception: Exception? = null) {
     checkEditableByUser()
     _fireEvent(Upload.StartedEvent(this, fileName, mimeType, 100L))
     receiver.receiveUpload(fileName, mimeType).use {  }
-    _fireEvent(Upload.FailedEvent(this, fileName, mimeType, 0L))
+    _fireEvent(Upload.FailedEvent(this, fileName, mimeType, 0L, exception))
     _fireEvent(Upload.FinishedEvent(this, fileName, mimeType, 0L))
 }

--- a/karibu-testing-v8/src/test/kotlin/com/github/mvysny/kaributesting/v8/UploadTest.kt
+++ b/karibu-testing-v8/src/test/kotlin/com/github/mvysny/kaributesting/v8/UploadTest.kt
@@ -106,10 +106,11 @@ class UploadTest : DynaTest({
         var startedCalled = false
         var failedCalled = false
         var finishedCalled = false
+        val exception = RuntimeException("simulated")
         upload.addFailedListener {
             expect("hello.txt") { it.filename }
             expect("text/plain") { it.mimeType }
-            expect(null) { it.reason }
+            expect(exception) { it.reason }
             failedCalled = true
         }
         upload.addStartedListener {
@@ -125,7 +126,10 @@ class UploadTest : DynaTest({
             expect("text/plain") { it.mimeType }
             finishedCalled = true
         }
-        upload._uploadFail("hello.txt")
+        upload._uploadFail(
+            fileName = "hello.txt",
+            exception = exception
+        )
         expect(true) { startedCalled }
         expect(true) { failedCalled }
         expect(true) { finishedCalled }


### PR DESCRIPTION
Hello Martin and team,
This PR adds the ability to provide an exception as a reason for Upload._uploadFail() call. I need a reason to be set in a FailedEvent to display an exception message to a user.
When is a release planned? Or should I proceed with a release as described on the page https://github.com/mvysny/karibu-testing/blob/master/CONTRIBUTING.md#releasing ?