### PR TITLE
Update dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The library supports Kotlin, Java and Groovy (Groovy support for Vaadin 14+ only
 ## News: UI Unit-Testing is being added to TestBench!
 
 The Vaadin UI Unit-Testing idea, pioneered by Karibu-Testing, proved useful for many Vaadin users.
-Vaadin recognized the effort and is adding official support for [UI unit-testing into TestBench](https://vaadin.com/docs/latest/tools/testbench/ui-unit-testing/overview).
+Vaadin recognized the effort and is adding official support for [UI unit-testing into TestBench](https://vaadin.com/docs/latest/testing/ui-unit).
 The Vaadin UI Unit-Testing is now available in alpha builds of TestBench for Vaadin 23.1.1;
 stable version will require at least Vaadin 23.2 (maybe higher).
 


### PR DESCRIPTION
Vaadin changed URL of "UI unit-testing into TestBench" from https://vaadin.com/docs/latest/tools/testbench/ui-unit-testing/overview to https://vaadin.com/docs/latest/testing/ui-unit