### PR TITLE
Add missing matcher methods for themes to Java API

### DIFF
--- a/karibu-testing-v10/src/main/java/com/github/mvysny/kaributesting/v10/SearchSpecJ.java
+++ b/karibu-testing-v10/src/main/java/com/github/mvysny/kaributesting/v10/SearchSpecJ.java
@@ -150,6 +150,28 @@ public class SearchSpecJ<T extends Component> {
     }
 
     /**
+     * If not null, the component must match all of these themes. Space-separated.
+     * @param themes expected space-separated themes.
+     * @return this
+     */
+    @NotNull
+    public SearchSpecJ<T> withThemes(@Nullable String themes) {
+        spec.setThemes(themes);
+        return this;
+    }
+
+    /**
+     * If not null, the component must NOT match any of these themes. Space-separated.
+     * @param themes space-separated themes, neither of which must be present on the component.
+     * @return this
+     */
+    @NotNull
+    public SearchSpecJ<T> withoutThemes(@Nullable String themes) {
+        spec.setWithoutThemes(themes);
+        return this;
+    }
+
+    /**
      * Adds additional predicate which the component needs to match. Not null.
      * <p/>
      * Please remember to provide a proper {@link Object#toString()} for the predicate,


### PR DESCRIPTION
The SearchSpecJ API is missing methods for matching themes (`withThemes`, `withoutThemes`). This PR adds the missing methods.

Fixes #172.