### PR TITLE
#207 Higher-fidelity MockPage.reload(): teleport overlays across @PreserveOnRefresh F5

### DIFF
--- a/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadinTest.kt
+++ b/karibu-testing-v10/kt10-tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadinTest.kt
@@ -10,12 +10,14 @@ import com.github.mvysny.karibudsl.v10.verticalLayout
 import com.github.mvysny.kaributesting.v10.mock.*
 import com.github.mvysny.kaributools.navigateTo
 import com.vaadin.flow.component.AttachEvent
+import com.vaadin.flow.component.Component
 import com.vaadin.flow.component.DetachEvent
 import com.vaadin.flow.component.Text
 import com.vaadin.flow.component.UI
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.html.Div
+import com.vaadin.flow.component.notification.Notification
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.page.ExtendedClientDetails
 import com.vaadin.flow.function.DeploymentConfiguration
@@ -395,6 +397,131 @@ abstract class AbstractMockVaadinTests() {
             val viewInstance = _get<PreserveOnRefreshView>()
             UI.getCurrent().page.reload()
             expect(true) { viewInstance === _get<PreserveOnRefreshView>() }
+        }
+    }
+
+    // Higher-fidelity F5 lifecycle: real Flow keeps the old UI alive while the new one navigates,
+    // so AbstractNavigationStateRenderer.disconnectElements() can teleport UI-level overlays
+    // (dialogs/notifications) onto the new UI for a @PreserveOnRefresh target, then close the old UI.
+    // https://github.com/mvysny/karibu-testing/issues/207
+    @Nested inner class `page reload F5 lifecycle (issue 207)` {
+        @Test fun `a dialog open across F5 survives on the new UI (@PreserveOnRefresh)`() {
+            navigateTo<PreserveOnRefreshView>()
+            val oldUI = UI.getCurrent()
+            var clicked = false
+            val okButton = Button("OK") { clicked = true }
+            val dialog = Dialog(okButton)
+            dialog.open()
+            _expectOne<Dialog>()   // flush the deferred attach, as if the dialog was opened in a prior request
+            expect(true) { dialog.isOpened }
+            expect(oldUI) { dialog.ui.get() }
+
+            oldUI.page.reload()
+
+            val newUI = UI.getCurrent()
+            expect(false) { newUI === oldUI }
+            // In real Flow the SAME overlay instance is moved onto the new UI - not dropped, not recreated.
+            expect(true) { dialog.isOpened }
+            expect(newUI) { dialog.ui.get() }
+            _get<Dialog>()   // the overlay is present on the new UI
+            // ...and it's still interactive: the same button instance still fires its listener.
+            okButton._click()
+            expect(true) { clicked }
+        }
+
+        @Test fun `the same dialog instance is teleported, not recreated`() {
+            navigateTo<PreserveOnRefreshView>()
+            val dialog = Dialog(Button("OK"))
+            dialog.open()
+            _expectOne<Dialog>()
+            UI.getCurrent().page.reload()
+            expect(true) { dialog === _get<Dialog>() }
+        }
+
+        @Test fun `a Notification teleports across F5 (@PreserveOnRefresh)`() {
+            navigateTo<PreserveOnRefreshView>()
+            val oldUI = UI.getCurrent()
+            val notification = Notification("hello")
+            notification.open()
+            _expectOne<Notification>()
+            expect(oldUI) { notification.ui.get() }
+
+            oldUI.page.reload()
+
+            val newUI = UI.getCurrent()
+            expect(true) { notification.isOpened }
+            expect(newUI) { notification.ui.get() }
+            _get<Notification>()
+        }
+
+        @Test fun `an overlay is NOT carried over across F5 of a non-@PreserveOnRefresh view`() {
+            navigateTo<HelloWorldView>()
+            val oldUI = UI.getCurrent()
+            val dialog = Dialog(Button("OK"))
+            dialog.open()
+            _expectOne<Dialog>()
+            expect(true) { dialog.isOpened }
+
+            oldUI.page.reload()
+
+            val newUI = UI.getCurrent()
+            _expectNone<Dialog>()   // the overlay is absent from the new UI
+            // it was not teleported: it stays behind on the discarded old UI, not moved onto the new one.
+            expect(false) { dialog.ui.orElse(null) === newUI }
+        }
+
+        @Test fun `child order on the new UI matches Flow (route root, then teleported overlays)`() {
+            navigateTo<PreserveOnRefreshView>()
+            val view = _get<PreserveOnRefreshView>()
+            val dialog1 = Dialog().apply { open() }
+            val dialog2 = Dialog().apply { open() }
+            _expect<Dialog>(2)
+
+            UI.getCurrent().page.reload()
+
+            // Karibu drives Flow's real navigation pipeline, so the child ordering it produces IS
+            // Flow's ordering: the preserved route root is re-attached first, then the overlays
+            // teleported off the old UI (via UIInternals.moveElementsFrom) are appended after it,
+            // preserving their relative order.
+            expect(listOf<Component>(view, dialog1, dialog2)) { UI.getCurrent().children.toList() }
+        }
+
+        @Test fun `old UI is marked closing after F5 (@PreserveOnRefresh)`() {
+            navigateTo<PreserveOnRefreshView>()
+            val oldUI = UI.getCurrent()
+            oldUI.page.reload()
+            expect(true) { oldUI.isClosing }
+        }
+
+        @Test fun `old UI is marked closing after F5 (plain view)`() {
+            navigateTo<HelloWorldView>()
+            val oldUI = UI.getCurrent()
+            oldUI.page.reload()
+            expect(true) { oldUI.isClosing }
+        }
+
+        @Test fun `session ends with exactly one live UI after F5`() {
+            navigateTo<PreserveOnRefreshView>()
+            val oldUI = UI.getCurrent()
+            oldUI.page.reload()
+            val session = VaadinSession.getCurrent()
+            expect(listOf(UI.getCurrent())) { session.uIs.toList() }
+            expect(false) { session.uIs.contains(oldUI) }
+        }
+
+        // The transient window where both the old and the new UI are live at the same time is a
+        // real production state (a "there is exactly one UI" assumption passes Karibu today but
+        // throws in production). The new UI is created & registered before it navigates, while the
+        // old one is still around.
+        @Test fun `both old and new UI are alive during the new UI init (transient two-UI window)`() {
+            navigateTo<PreserveOnRefreshView>()
+            val oldUI = UI.getCurrent()
+            var uiCountDuringInit = -1
+            VaadinService.getCurrent().addUIInitListener { event ->
+                uiCountDuringInit = event.ui.session.uIs.size
+            }
+            oldUI.page.reload()
+            expect(2) { uiCountDuringInit }
         }
     }
 

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadin.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadin.kt
@@ -129,6 +129,55 @@ public object MockVaadin {
     }
 
     /**
+     * Simulates a browser F5 reload of the current UI, as closely to real Vaadin Flow
+     * as a server-side-only test double allows. See
+     * [issue 207](https://github.com/mvysny/karibu-testing/issues/207) for the full analysis.
+     *
+     * Real Flow keeps the *old* UI alive while the *new* UI navigates, so that
+     * [com.vaadin.flow.router.internal.AbstractNavigationStateRenderer] `.disconnectElements()`
+     * can, for a [com.vaadin.flow.router.PreserveOnRefresh] target:
+     * 1. mark the old UI with Flow's internal `ReplacedViaPreserveOnRefresh` sentinel (via
+     *    `Element.removeFromTree()`),
+     * 2. **teleport UI-level overlays (dialogs/notifications) off the old UI onto the new UI**
+     *    (via [com.vaadin.flow.component.internal.UIInternals.moveElementsFrom]),
+     * 3. close the old UI.
+     *
+     * Because Karibu drives Flow's *real* navigation pipeline, we get all of the above (the
+     * sentinel, the overlay teleport, the overlays-before-route child ordering and `oldUI.close()`)
+     * for free - **as long as the old UI is still alive and still owns the preserved route root
+     * when the new UI navigates.** So the sole job here is to fix the ordering: create the new UI
+     * first, then discard the old one.
+     *
+     * For a non-[com.vaadin.flow.router.PreserveOnRefresh] target Flow does not go through
+     * `disconnectElements()`; the browser's unload beacon closes the old UI instead. We emulate
+     * that by closing the old UI ourselves, so [UI.isClosing] is consistent regardless of the
+     * navigation target.
+     */
+    internal fun reloadCurrentUI(uiFactory: () -> UI, session: VaadinSession) {
+        val oldUI: UI = checkNotNull(UI.getCurrent()) { "No current UI to reload" }
+        // remember the current location so the new UI navigates to the same place.
+        lastUILocation.set(oldUI.internals.activeViewLocation)
+
+        // Deliberately DO NOT close/detach the old UI yet: it must stay alive & registered in the
+        // session so that the new UI's navigation can teleport overlays off it (see kdoc above).
+        // The new UI gets a fresh uiId so it doesn't evict the old one from VaadinSession.uIs.
+        createUI(uiFactory, session, uiId = oldUI.uiId + 1)
+        val newUI: UI = checkNotNull(UI.getCurrent())
+
+        // Now discard the old UI, mirroring Vaadin's end-of-request cleanup.
+        // Flow's disconnectElements() already closed the old UI for a @PreserveOnRefresh target;
+        // for any other target we close it here to emulate the browser unload beacon.
+        // UI._close() removes the UI from the session and fires the detach listeners; it asserts
+        // that the UI being removed is the current one, so briefly restore the old UI as current.
+        UI.setCurrent(oldUI)
+        try {
+            oldUI._close()
+        } finally {
+            UI.setCurrent(newUI)
+        }
+    }
+
+    /**
      * Cleans up and removes the Vaadin UI and Vaadin Session. You can call this function in `afterEach{}` block,
      * to clean up after the test. This comes handy when you want to be extra-sure that the next test won't accidentally reuse old UI,
      * should you forget to call [setup] properly.
@@ -251,7 +300,7 @@ public object MockVaadin {
         createUI(uiFactory, session)
     }
 
-    internal fun createUI(uiFactory: () -> UI, session: VaadinSession) {
+    internal fun createUI(uiFactory: () -> UI, session: VaadinSession, uiId: Int = 1) {
         val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent())
         val ui: UI = uiFactory()
         require(ui.session == null) {
@@ -268,7 +317,10 @@ public object MockVaadin {
         }
         ui.internals.session = session
         UI.setCurrent(ui)
-        ui.doInit(request, 1, "ROOT-1")
+        // uiId doubles as the key in VaadinSession.uIs; a reloaded UI must therefore get a fresh
+        // uiId, otherwise session.addUI() would evict the old (still-live) UI from the session,
+        // breaking the transient two-live-UI window that real Flow exhibits across an F5.
+        ui.doInit(request, uiId, "ROOT-1")
         strongRefUI.set(ui)
 
         session.addUI(ui)
@@ -471,8 +523,7 @@ private class MockPage(private val ui: UI, private val uiFactory: () -> UI, priv
     override fun reload() {
         // recreate the UI on reload(), to simulate browser's F5
         super.reload()
-        MockVaadin.closeCurrentUI(true)
-        MockVaadin.createUI(uiFactory, session)
+        MockVaadin.reloadCurrentUI(uiFactory, session)
     }
 
     /**


### PR DESCRIPTION
Fixes #207.

## Problem

`MockPage.reload()` closed & detached the old UI **before** creating the new one:

```kotlin
MockVaadin.closeCurrentUI(true)          // detach/close OLD ui first
MockVaadin.createUI(uiFactory, session)  // NEW ui after
```

Real Flow does the opposite. On an F5 of a `@PreserveOnRefresh` view it keeps the old UI alive while the new UI navigates, so `AbstractNavigationStateRenderer.disconnectElements()` can:

1. mark the old UI with the internal `ReplacedViaPreserveOnRefresh` sentinel (`Element.removeFromTree`),
2. **teleport UI-level overlays (dialogs/notifications) off the old UI onto the new UI** (`UIInternals.moveElementsFrom`),
3. `oldUI.close()`.

Under the old ordering the preserved route survived (it's cached in the session's `PreservedComponentCache`), but any open `Dialog`/`Notification` was silently dropped — `component.getUI()` was already empty by the time the new UI navigated, so Flow's teleport branch never ran.

## Fix

Karibu drives Flow's **real** navigation pipeline, so the fix is just to reorder: create the new UI first and keep the old one alive & registered until after navigation. Flow itself then performs the overlay teleport, sets the sentinel, produces the correct child ordering, and closes the old UI — nothing is re-implemented, so it can't drift from Flow again. Afterwards Karibu discards the old UI (fires detach + removes it from the session).

Two supporting details:
- **Fresh `uiId` for the reloaded UI.** `uiId` is the key in `VaadinSession.uIs`; reusing `1` made `session.addUI()` evict the still-live old UI, collapsing the transient two-live-UI window that production exhibits across an F5.
- **Non-`@PreserveOnRefresh` reloads** keep the simpler behavior; the old UI is closed here to emulate the browser unload beacon, so `UI.isClosing()` is consistent regardless of the navigation target.

## Tests

New `page reload F5 lifecycle (issue 207)` suite in `MockVaadinTest` (runs in all four `kt10-testrun-vaadin24*` environments — LTS + next, WAR + jar-module):

- a `Dialog` open across F5 survives on the new UI (same instance, `isOpened`, findable, its button still clickable) — the issue's headline scenario;
- the same dialog instance is teleported, not recreated;
- a `Notification` teleports across F5;
- an overlay is **not** carried over across F5 of a non-`@PreserveOnRefresh` view;
- child order on the new UI matches Flow (route root, then teleported overlays);
- old UI is `isClosing()` after F5 (both preserve and plain paths);
- session ends with exactly one live UI after F5;
- both old and new UI are alive during the new UI's init (the transient two-UI window).

All existing reload tests and the full `./gradlew test` battery pass across all four environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)