### PR TITLE
Route unload-beacon simulation through the real ServerRpcHandler (#210)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Handoff when an idea ships: delete its `ideas/` file, record the rationale as a 
 - `./gradlew :karibu-testing-v24:testrun-stable-webapp:test --tests "AllTests.flow-build-info-json exists"` — run a single test.
 - JDK 21 is the minimum (enforced in `build.gradle.kts`). CI matrix covers JDK 21 and 25 on Linux/macOS/Windows.
 - Dependency versions (Vaadin, Kotlin, JUnit, kaributools, etc.) live in `gradle/libs.versions.toml` — edit there, not in individual `build.gradle.kts` files.
+- **Supported Vaadin version.** Karibu-Testing **2.6.0+ (the current line, incl. the `2.7.x-SNAPSHOT` we ship) supports Vaadin 25+ *only*.** Vaadin 24 is supported only up to KT 2.4.x; 2.5.x is a do-not-use dead end. Full KT-version → Vaadin-version table: the compatibility chart at the top of `karibu-testing-v10/README.md` — treat it as the source of truth over any Vaadin-24 references that survive elsewhere.
 
 ## Release process
 
@@ -56,7 +57,7 @@ Tests for the library itself do **not** live next to the code they test. Instead
 
 Consequence: when you add a new test, put it in `karibu-testing-v10:tests` (or `karibu-testing-v23:tests` if it needs Vaadin 23+ APIs), and it will automatically run in every environment. When debugging an environment-specific failure, run the specific `testrun-*` module.
 
-**Caveat — mind which Vaadin version you're reasoning about vs. testing against.** The library *compiles* against `libs.vaadin.stable.all` (one pinned version, currently 25.x), but the tests *run* against several different Vaadin versions (24 LTS and `vaadin_next`), and Vaadin's own class hierarchies shift between them. For example, `TextRenderer` and `ComponentRenderer` **extend `LitRenderer` in Vaadin 24** but **not** in Vaadin 25. So when you inspect a Vaadin jar / `javap` / source to predict behavior, confirm it's the *same* version the failing test actually runs with — a 25.x jar will mislead you about a Vaadin-24 test run, and vice versa.
+**Caveat — mind which Vaadin version you're reasoning about vs. testing against.** The library *compiles* against `libs.vaadin.stable.all` (one pinned version, `vaadin` in `libs.versions.toml`, currently 25.2.x), but the tests *run* against two different Vaadin versions: the same `stable` and the newer prerelease `vaadin_next` (currently a 25.3 alpha). Vaadin's own class hierarchies and internals shift between them (e.g. an internal method extracted or a class's supertype changed between 25.2 and 25.3). So when you inspect a Vaadin jar / `javap` / source to predict behavior, confirm it's the *same* version the failing test actually runs with — a `stable` jar can mislead you about a `next` test run, and vice versa. (Both are Vaadin 25+; KT no longer runs against Vaadin 24 — see the compatibility chart in `karibu-testing-v10/README.md`.)
 
 ## API conventions
 
@@ -67,6 +68,6 @@ Consequence: when you add a new test, put it in `karibu-testing-v10:tests` (or `
 
 ## Dependency notes
 
-- v10 and v23 use `compileOnly(libs.vaadin.v24.all)` — the library does **not** pull Vaadin transitively; the consuming app picks its Vaadin version. Preserve this pattern when adding dependencies.
+- v10 and v23 use `compileOnly(libs.vaadin.stable.all)` — the library does **not** pull Vaadin transitively; the consuming app picks its Vaadin version. Preserve this pattern when adding dependencies.
 - `fake-servlet5` (separate library by the same author) provides the `jakarta.servlet` fakes — we don't roll our own.
 - `kaributools` / `kaributools23` (separate libraries) provide general Vaadin utilities (e.g. `VaadinVersion`) that Karibu-Testing builds on.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -9,6 +9,80 @@ Newest entries on top.
 
 ---
 
+## 2026-07-21 — Deliver the F5/tab-close unload beacon through Flow's *real* `ServerRpcHandler`
+
+**Context.** [#210](https://github.com/mvysny/karibu-testing/issues/210): the F5/beacon design below
+(2026-07-06) *reimplemented* the browser unload beacon in Kotlin — Karibu decided "close the old UI"
+itself and mirrored `ServerRpcHandler.isPreserveOnRefreshTarget`. Two costs: (a) a custom
+`ServerRpcHandler` (e.g. a tab-scope add-on hooking `handleUnloadBeaconRequest`) was **invisible** to
+Karibu tests — the beacon never reached it; (b) `MockBrowser.closeTab` force-detached a
+`@PreserveOnRefresh` UI, whereas real Flow *ignores* the beacon for such a UI and leaves it lingering
+until the heartbeat reap. The proposal: route beacon simulation through the app's actual handler.
+
+**What real Flow does (traced against flow-server 25.2.4 & 25.3.0-alpha3).** A closing tab POSTs an
+unload beacon; `UidlRequestHandler.getRpcHandler().handleRpc(ui, body, request)` runs it. Beacon
+detection is just `json.has(ApplicationConstants.UNLOAD_BEACON)` (`"UNLOAD"`); the marker makes
+`RpcRequest` skip the sync-id and client-id checks. `handleUnloadBeaconRequest` (extracted into a
+`protected` method in 25.2; inline in `handleRpc` before that) closes a normal UI but **ignores the
+beacon for a `@PreserveOnRefresh` target**. The app customizes the handler by overriding
+`UidlRequestHandler.createRpcHandler()` (installed via `VaadinService.createRequestHandlers()`).
+
+**Decisions.**
+
+1. **Route through the *public* `handleRpc(UI, String, VaadinRequest)`, not the protected
+   `handleUnloadBeaconRequest`.** `deliverUnloadBeacon(ui)` builds a minimal beacon **string** —
+   `{"csrfToken":<ui token>,"rpcInvocations":[],"UNLOAD":0}` — and lets Flow parse it. Consequences:
+   Karibu never touches Flow's version-specific internal JSON types (it only produces a String); the
+   empty `rpcInvocations` keeps `handleInvocations()` a no-op (a `null` array NPEs — it is
+   dereferenced immediately); the CSRF token matches the UI's so `isCsrfTokenValid` passes whatever
+   the XSRF config; and it works on every supported version (public `handleRpc` is ancient), unlike
+   `handleUnloadBeaconRequest` which is 25.2+.
+
+2. **Reach the app's *custom* handler via `UidlRequestHandler.createRpcHandler()`, reflectively.**
+   `deliverUnloadBeacon` pulls the `UidlRequestHandler` from `service.getRequestHandlers()` and
+   invokes its `protected createRpcHandler()` by reflection (one reflective call; consistent with
+   Karibu's existing reflection style). This is what makes a custom `ServerRpcHandler` observable —
+   the whole point of the issue. Rejected: the fully-public `synchronizedHandleRequest(session,
+   request, response, body)` — it re-derives the UI from a `v-uiId` request param and then
+   `writeUidl()`s a response, both pointless (and fragile) noise for a close simulation.
+
+3. **Split close (Flow's) from finalize (Karibu's).** `handleRpc` only sets `UI.isClosing`; Flow's
+   end-of-request `removeClosedUIs()` does the detach + `session.removeUI`. Karibu mirrors that split:
+   `deliverUnloadBeacon` sets `isClosing` (or not, for preserve), then `finalizeClosedUI(ui)` removes
+   it **iff** `isClosing`. The `EAGER`/`LATE`/`NEVER` knob is now *when Karibu delivers the beacon and
+   finalizes* relative to new-UI creation — not *what the beacon does*. `NEVER` = don't deliver.
+
+4. **`closeTab` lets Flow decide the tab's fate.** Beacon delivered → normal UI removed immediately;
+   `@PreserveOnRefresh` UI (beacon ignored → `isClosing` stays false) is flagged
+   `UNLOAD_BEACON_LOST_KEY` and left lingering for `reapInactiveUIs`, exactly as a real browser leaves
+   it for the heartbeat. **Behavioral change** vs. the prior force-detach.
+
+5. **Kept `isPreserveOnRefreshTarget` (did *not* fully delete the mirror).** For a preserve target the
+   close is *navigation-driven* (the new UI's `disconnectElements()` teleports overlays off the old UI
+   and closes it), not beacon-driven — the beacon is a no-op there. So the reload path still needs
+   preserve-awareness to order new-UI-creation vs. beacon delivery (enforced by
+   `@PreserveOnRefresh ignores {EAGER,LATE,NEVER} timing` tests). The "mirror" is a 3-line annotation
+   read on the public `activeRouterTargetsChain`, negligible drift risk. Partial win #3; accepted.
+
+**Consequences / limitations.** A custom `ServerRpcHandler` now sees the beacon (new tests:
+`unload beacon reaches a custom ServerRpcHandler (issue 210)`), and closing a `@PreserveOnRefresh`
+tab now lingers-then-reaps instead of detaching (new test in `MockBrowserTest`). `createRpcHandler()`
+is invoked per delivery, yielding a fresh handler instance each time (Flow caches one via
+`getRpcHandler()`); fine for the stateless norm, revisit if a stateful custom handler needs it. The
+`closeTab`-preserve behavioral change may warrant a major-version note in the changelog.
+
+**Supersedes** decision #1 ("Reorder rather than re-implement") of the 2026-07-06 F5/beacon entry
+below *for the non-preserve path*: the old UI is no longer closed by Karibu directly but by Flow's
+real handler. The preserve path (nav-driven teleport + close) is unchanged.
+
+**Where it lives.** `MockVaadin.deliverUnloadBeacon()` / `obtainServerRpcHandler()` /
+`finalizeClosedUI()` / `reloadCurrentUI()` / `discardUI()`; `MockBrowser.closeTab` KDoc. Tests:
+`MockVaadinTest` (`unload beacon reaches a custom ServerRpcHandler (issue 210)`, plus the unchanged
+`unload beacon timing on F5` matrix) and `MockBrowserTest` (`closing a @PreserveOnRefresh tab leaves
+it lingering until reapInactiveUIs`).
+
+---
+
 ## 2026-07-07 — Rename stale `v24`/`kt10` build tokens to `stable`/`next` + `testrun-*`
 
 **Context.** The Gradle Vaadin-dependency aliases were named `vaadin-v24-*` / `vaadin-v24next-*`

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockBrowser.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockBrowser.kt
@@ -108,8 +108,12 @@ public object MockBrowser {
      * Closes the tab identified by [windowName].
      *
      * By default ([beaconLost] `= false`) this models the normal case: the browser's unload beacon is
-     * delivered, so the tab's [UI] is closed, detached and removed from the session immediately -
-     * exactly as an F5 reload closes the old UI.
+     * delivered - through the app's real `ServerRpcHandler`, so a custom handler sees it - and Flow
+     * decides the tab's fate. A normal tab's [UI] is closed, detached and removed from the session
+     * immediately, exactly as an F5 reload closes the old UI. A
+     * [com.vaadin.flow.router.PreserveOnRefresh] tab, whose beacon Flow **ignores**, is instead left
+     * lingering (like a real browser leaves it for the heartbeat cleanup) and reaped by a later
+     * [MockVaadin.reapInactiveUIs].
      *
      * With [beaconLost] `= true` it models a **lost** unload beacon (the tab closed but the server
      * never learned): the UI is *not* removed but left lingering, flagged so a later

--- a/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadin.kt
+++ b/karibu-testing-v10/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadin.kt
@@ -17,6 +17,9 @@ import com.vaadin.flow.router.Location
 import com.vaadin.flow.router.NavigationTrigger
 import com.vaadin.flow.router.PreserveOnRefresh
 import com.vaadin.flow.server.*
+import com.vaadin.flow.server.communication.ServerRpcHandler
+import com.vaadin.flow.server.communication.UidlRequestHandler
+import com.vaadin.flow.shared.ApplicationConstants
 import com.vaadin.flow.shared.communication.PushMode
 import java.lang.reflect.Field
 import java.util.concurrent.ExecutionException
@@ -167,11 +170,13 @@ public object MockVaadin {
      * has no effect.
      *
      * **Non-[com.vaadin.flow.router.PreserveOnRefresh] target.** Flow does not go through
-     * `disconnectElements()`; the browser's unload beacon closes the old UI instead. Its timing
-     * relative to the creation of the new UI is best-effort in a real browser, so it is configurable
-     * via [KaribuConfig.unloadBeaconTiming] ([UnloadBeaconTiming.EAGER] by default). Either way the
-     * old UI ends up closed (via [UI.close]), detached and removed from the session - matching Flow's
-     * `ui.close()` + end-of-request `removeClosedUIs()`.
+     * `disconnectElements()`; the browser's unload beacon closes the old UI instead. Karibu delivers
+     * that beacon through the app's real [ServerRpcHandler] (see [deliverUnloadBeacon]) rather than
+     * reimplementing the close, so a custom handler is exercised and the close decision stays Flow's.
+     * The beacon's timing relative to the creation of the new UI is best-effort in a real browser, so
+     * it is configurable via [KaribuConfig.unloadBeaconTiming] ([UnloadBeaconTiming.EAGER] by
+     * default). Either way the old UI ends up closed (via [UI.close]), detached and removed from the
+     * session - matching Flow's `ui.close()` + end-of-request `removeClosedUIs()`.
      */
     internal fun reloadCurrentUI(uiFactory: () -> UI, session: VaadinSession, newWindowName: String? = null) {
         val oldUI: UI = checkNotNull(UI.getCurrent()) { "No current UI to reload" }
@@ -187,27 +192,102 @@ public object MockVaadin {
         // nor any other open browser tab.
         if (isPreserveOnRefreshTarget(oldUI)) {
             // Keep the old UI alive & registered so the new UI's navigation can teleport overlays
-            // off it and close it (see kdoc). Then discard the old UI.
+            // off it and close it (see kdoc). Then discard the old UI. Flow ignores the unload beacon
+            // for a @PreserveOnRefresh target, so we do not deliver one here.
             createUI(uiFactory, session, windowName = windowName)
             discardOldUI(oldUI)
         } else when (KaribuConfig.unloadBeaconTiming) {
             UnloadBeaconTiming.EAGER -> {
-                // Beacon before the new UI exists: close+detach+remove the old UI, then create the new.
-                discardOldUI(oldUI)
+                // Beacon before the new UI exists: deliver it (Flow closes the old UI), finalize the
+                // close (detach+remove), then create the new UI.
+                deliverUnloadBeacon(oldUI)
+                finalizeClosedUI(oldUI)
                 createUI(uiFactory, session, windowName = windowName)
             }
             UnloadBeaconTiming.LATE -> {
-                // Beacon after the new UI is created: both are briefly live, then the old UI is
-                // closed+detached+removed.
+                // Beacon after the new UI is created: deliver it (Flow closes the old UI), create the
+                // new UI (both briefly live), then finalize the old UI's close.
+                deliverUnloadBeacon(oldUI)
                 createUI(uiFactory, session, windowName = windowName)
-                discardOldUI(oldUI)
+                finalizeClosedUI(oldUI)
             }
             UnloadBeaconTiming.NEVER -> {
-                // Beacon lost: leave the old UI alive alongside the new one. Flag it so
-                // reapInactiveUIs() can later close it the way Flow's heartbeat/idle-UI cleanup would.
+                // Beacon lost: never delivered, so the old UI lingers alive alongside the new one.
+                // Flag it so reapInactiveUIs() can later close it the way Flow's heartbeat/idle-UI
+                // cleanup would.
                 ComponentUtil.setData(oldUI, UNLOAD_BEACON_LOST_KEY, true)
                 createUI(uiFactory, session, windowName = windowName)
             }
+        }
+    }
+
+    /**
+     * Delivers a browser unload beacon (`navigator.sendBeacon`, a POST with `UNLOAD=…`) to [ui]
+     * through the app's *real* - and possibly customized -
+     * [com.vaadin.flow.server.communication.ServerRpcHandler], i.e. the exact server code path a
+     * closing browser tab hits. This is what lets a custom `ServerRpcHandler` (e.g. a tab-scope
+     * add-on that hooks `handleUnloadBeaconRequest`) observe the beacon in a Karibu test, and it
+     * delegates the "should the UI close?" decision to Flow itself: Flow closes a normal UI
+     * ([UI.isClosing] becomes `true`) but deliberately **ignores** the beacon for a
+     * [PreserveOnRefresh] target, leaving that UI alive.
+     *
+     * Only [UI.close] (setting [UI.isClosing]) happens here; the subsequent detach +
+     * [VaadinSession.removeUI] - Flow's end-of-request `removeClosedUIs()` - is done separately by
+     * [finalizeClosedUI], so the caller controls its timing relative to the new UI's creation.
+     *
+     * The beacon is a JSON **string** we hand to the stable, public
+     * `ServerRpcHandler.handleRpc(UI, String, VaadinRequest)`, so Karibu never touches Flow's
+     * version-specific internal JSON types - Flow parses it. The message is minimal: the
+     * [ApplicationConstants.UNLOAD_BEACON] marker makes `ServerRpcHandler` skip the sync-id and
+     * client-id checks, the empty [ApplicationConstants.RPC_INVOCATIONS] array keeps
+     * `handleInvocations()` a no-op, and the CSRF token matches [ui]'s so it passes
+     * [VaadinService.isCsrfTokenValid] whatever the XSRF config.
+     */
+    private fun deliverUnloadBeacon(ui: UI) {
+        val request: VaadinRequest = checkNotNull(VaadinRequest.getCurrent()) {
+            "No current VaadinRequest - was MockVaadin.setup() called?"
+        }
+        val handler: ServerRpcHandler = obtainServerRpcHandler(ui.session.service)
+        val message = """{"${ApplicationConstants.CSRF_TOKEN}":"${ui.csrfToken}",""" +
+                """"${ApplicationConstants.RPC_INVOCATIONS}":[],""" +
+                """"${ApplicationConstants.UNLOAD_BEACON}":0}"""
+        // handleRpc / UI.close() operate on the given UI; make it current for the duration (it may be
+        // a background tab in closeTab), then restore.
+        val previous: UI? = UI.getCurrent()
+        UI.setCurrent(ui)
+        try {
+            handler.handleRpc(ui, message, request)
+        } finally {
+            UI.setCurrent(if (previous === ui) null else previous)
+        }
+    }
+
+    /**
+     * Returns the app's [ServerRpcHandler] the way Flow does: from the [UidlRequestHandler] installed
+     * in the service's request-handler chain. `UidlRequestHandler.createRpcHandler()` is `protected`,
+     * so it is invoked reflectively - which honors a custom `UidlRequestHandler` that overrides it to
+     * install a custom `ServerRpcHandler` (the whole point of routing the beacon through the real
+     * handler; karibu-testing issue #210).
+     */
+    private fun obtainServerRpcHandler(service: VaadinService): ServerRpcHandler {
+        val uidlHandler: UidlRequestHandler = service.requestHandlers
+            .filterIsInstance<UidlRequestHandler>()
+            .firstOrNull()
+            ?: throw IllegalStateException("No UidlRequestHandler in $service's request handlers - cannot deliver an unload beacon")
+        val createRpcHandler = UidlRequestHandler::class.java.getDeclaredMethod("createRpcHandler")
+        createRpcHandler.isAccessible = true
+        return createRpcHandler.invoke(uidlHandler) as ServerRpcHandler
+    }
+
+    /**
+     * Flow's end-of-request `removeClosedUIs()`: if [ui] was closed by a delivered beacon
+     * ([UI.isClosing]), detach it and remove it from the session (see [discardOldUI]). A no-op if the
+     * UI is still alive - e.g. the beacon was ignored for a [PreserveOnRefresh] target - or already
+     * removed.
+     */
+    private fun finalizeClosedUI(ui: UI) {
+        if (ui.isClosing && ui.session != null) {
+            discardOldUI(ui)
         }
     }
 
@@ -478,11 +558,21 @@ public object MockVaadin {
     }
 
     /**
-     * Closes, detaches and removes [ui] from its session - see [discardOldUI]. Exposed for
-     * [MockBrowser.closeTab] (beacon delivered).
+     * Models a browser tab closing with its unload beacon **delivered**: routes the beacon through
+     * the app's real [ServerRpcHandler] (see [deliverUnloadBeacon]) and lets Flow decide the tab's
+     * fate. A normal UI is closed, detached and removed immediately; a [PreserveOnRefresh] UI - whose
+     * beacon Flow ignores - is instead left lingering and flagged for [reapInactiveUIs], exactly as a
+     * real browser leaves it for the heartbeat/idle-UI cleanup. Exposed for [MockBrowser.closeTab].
      */
     internal fun discardUI(ui: UI) {
-        discardOldUI(ui)
+        deliverUnloadBeacon(ui)
+        if (ui.isClosing) {
+            finalizeClosedUI(ui)
+        } else {
+            // Flow ignored the beacon (@PreserveOnRefresh): the tab's UI lingers until the heartbeat
+            // reap, which reapInactiveUIs() emulates.
+            markUnloadBeaconLost(ui)
+        }
     }
 
     /**

--- a/karibu-testing-v10/tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockBrowserTest.kt
+++ b/karibu-testing-v10/tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockBrowserTest.kt
@@ -150,6 +150,24 @@ abstract class AbstractMockBrowserTests {
             expect(false) { session.uIs.contains(tab) }
         }
 
+        // issue #210: Flow ignores the unload beacon for a @PreserveOnRefresh target, so closing such
+        // a tab must leave its UI lingering (as a real browser does, until the heartbeat reap) rather
+        // than detach it immediately - the fidelity gap the real-handler beacon delivery fixes.
+        @Test fun `closing a @PreserveOnRefresh tab leaves it lingering until reapInactiveUIs`() {
+            val tab = MockBrowser.newTab("tab-B", "preserveonrefresh")
+            MockBrowser.switchTo(MockBrowser.tabs.first { it != "tab-B" })
+
+            MockBrowser.closeTab("tab-B")
+            // Flow ignored the beacon: the tab's UI is still there, not closed.
+            expect(true) { session.uIs.contains(tab) }
+            expect(false) { tab.isClosing }
+
+            MockVaadin.reapInactiveUIs()
+            // the heartbeat reap eventually closes and removes it.
+            expect(true) { tab.isClosing }
+            expect(false) { session.uIs.contains(tab) }
+        }
+
         @Test fun `the current tab cannot be closed (beacon delivered)`() {
             expectThrows<IllegalArgumentException>("Cannot close the currently focused tab") {
                 MockBrowser.closeTab(MockBrowser.currentWindowName)

--- a/karibu-testing-v10/tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadinTest.kt
+++ b/karibu-testing-v10/tests/src/main/kotlin/com/github/mvysny/kaributesting/v10/MockVaadinTest.kt
@@ -24,6 +24,9 @@ import com.vaadin.flow.function.DeploymentConfiguration
 import com.vaadin.flow.router.*
 import com.vaadin.flow.server.*
 import com.vaadin.flow.server.auth.AnonymousAllowed
+import com.vaadin.flow.server.communication.ServerRpcHandler
+import com.vaadin.flow.server.communication.UidlRequestHandler
+import com.vaadin.flow.shared.ApplicationConstants
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -652,6 +655,59 @@ abstract class AbstractMockVaadinTests() {
         @Test fun `@PreserveOnRefresh ignores NEVER timing`() {
             KaribuConfig.unloadBeaconTiming = UnloadBeaconTiming.NEVER
             verifyPreserveUnaffectedByTiming()
+        }
+    }
+
+    // issue #210: Karibu delivers the unload beacon through the app's *real* (possibly customized)
+    // ServerRpcHandler, so a tab-scope add-on that hooks handleUnloadBeaconRequest is exercised by
+    // Karibu tests - instead of Karibu reimplementing the close and leaving the custom handler blind.
+    @Nested inner class `unload beacon reaches a custom ServerRpcHandler (issue 210)` {
+        /** Counts how many unload beacons the app's own ServerRpcHandler observes. */
+        private var beaconsSeen = 0
+
+        /**
+         * Re-runs [MockVaadin.setup] with a custom [UidlRequestHandler] whose [ServerRpcHandler]
+         * counts the unload beacons it is handed - the way a tab-scope add-on would hook them.
+         */
+        private fun setupWithCountingRpcHandler() {
+            MockVaadin.tearDown()
+            beaconsSeen = 0
+            val countingHandler = object : ServerRpcHandler() {
+                override fun handleUnloadBeaconRequest(ui: UI, rpcRequest: RpcRequest) {
+                    if (rpcRequest.rawJson.has(ApplicationConstants.UNLOAD_BEACON)) beaconsSeen++
+                    super.handleUnloadBeaconRequest(ui, rpcRequest)
+                }
+            }
+            MockVaadin.setup(servlet = object : MockVaadinServlet(routes) {
+                override fun createServletService(deploymentConfiguration: DeploymentConfiguration): VaadinServletService {
+                    val service = object : MockService(this, deploymentConfiguration) {
+                        override fun createRequestHandlers(): MutableList<RequestHandler> {
+                            val handlers = super.createRequestHandlers()
+                            val i = handlers.indexOfFirst { it is UidlRequestHandler }
+                            handlers[i] = object : UidlRequestHandler() {
+                                override fun createRpcHandler(): ServerRpcHandler = countingHandler
+                            }
+                            return handlers
+                        }
+                    }
+                    service.init()
+                    return service
+                }
+            })
+        }
+
+        @Test fun `F5 reload of a plain view delivers the beacon to the custom handler`() {
+            setupWithCountingRpcHandler()   // the default WelcomeView is a plain, non-@PreserveOnRefresh view
+            UI.getCurrent().page.reload()
+            expect(1) { beaconsSeen }
+        }
+
+        @Test fun `closing a tab delivers the beacon to the custom handler`() {
+            setupWithCountingRpcHandler()
+            MockBrowser.newTab("tab-B")
+            MockBrowser.switchTo(MockBrowser.tabs.first { it != "tab-B" })
+            MockBrowser.closeTab("tab-B")
+            expect(1) { beaconsSeen }
         }
     }
 


### PR DESCRIPTION
Fixes #210.

## Problem
Karibu simulated the browser unload beacon by **reimplementing** it in Kotlin — it decided "close the old UI" itself and mirrored `ServerRpcHandler.isPreserveOnRefreshTarget`. Two costs:
1. A custom `ServerRpcHandler` (e.g. a tab-scope add-on hooking `handleUnloadBeaconRequest`) was **invisible** to Karibu tests — the beacon never reached it.
2. `MockBrowser.closeTab` **force-detached** a `@PreserveOnRefresh` UI, whereas real Flow *ignores* the beacon for such a UI and leaves it lingering until the heartbeat reap.

## Change
Deliver the beacon through the app's **actual** handler:
- `deliverUnloadBeacon(ui)` builds a minimal beacon **string** — `{"csrfToken":<ui token>,"rpcInvocations":[],"UNLOAD":0}` — and feeds it to the **public** `ServerRpcHandler.handleRpc(UI, String, VaadinRequest)`. Karibu never touches Flow's version-specific internal JSON types; Flow parses the string.
- The handler is the app's own: pulled from the installed `UidlRequestHandler` via its `createRpcHandler()` (one reflective call), so a **custom** `ServerRpcHandler` is honored.
- Flow makes the close decision (`isClosing`); Karibu only times the finalize (detach + `removeUI`). The `EAGER`/`LATE`/`NEVER` knob and all prior behavior are preserved.

### Why the public `handleRpc` and not `handleUnloadBeaconRequest`
`handleUnloadBeaconRequest` is `protected` **and only exists in 25.2+**; the public `handleRpc` is ancient and portable, needs no reflection into version-gated methods, and still runs the custom handler's override.

## Fidelity gains
- ✅ Custom `ServerRpcHandler` observes the beacon on **F5 reload** and **`closeTab`**.
- ✅ `@PreserveOnRefresh` tab **lingers-then-reaps** on close (was: force-detached).
- ⚠️ `isPreserveOnRefreshTarget` is **kept**: for a preserve target the close is *navigation-driven*, not beacon-driven, so the reload path still needs preserve-awareness to order new-UI-creation vs. beacon delivery. Full mirror deletion isn't possible.

## Behavioral change
Closing a `@PreserveOnRefresh` tab now lingers (reap-eligible) instead of detaching immediately — more faithful, but a behavior change worth a changelog/major-version note.

## Tests
- New `unload beacon reaches a custom ServerRpcHandler (issue 210)` (F5 + closeTab) proves the custom handler is invoked.
- New `closing a @PreserveOnRefresh tab leaves it lingering until reapInactiveUIs` in `MockBrowserTest`.
- The full existing `unload beacon timing on F5` / `page reload F5 lifecycle` matrix passes unchanged.
- `./gradlew test` green across all four testrun variants (Vaadin 25.2.3 stable + 25.3.0-alpha5 next × webapp + module).

Rationale recorded in `DECISIONS.md`. Also backported the KT-2.6+/Vaadin-25+ support fact into `CLAUDE.md` and fixed its stale `v24`/`24 LTS` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)